### PR TITLE
feat: add floating scroll-to-top button

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,7 +26,8 @@ import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
 
-const ScrollToTop = () => {
+// Component to scroll to top on route change
+const ScrollToTopOnRouteChange = () => {
   const { pathname } = useLocation();
 
   useEffect(() => {
@@ -34,6 +35,50 @@ const ScrollToTop = () => {
   }, [pathname]);
 
   return null;
+};
+
+// NEW: Floating Scroll to Top Button Component
+const ScrollToTopButton = () => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  // Show button when page is scrolled down
+  const toggleVisibility = () => {
+    if (window.pageYOffset > 300) {
+      setIsVisible(true);
+    } else {
+      setIsVisible(false);
+    }
+  };
+
+  // Scroll to top smoothly
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth'
+    });
+  };
+
+  useEffect(() => {
+    window.addEventListener('scroll', toggleVisibility);
+    
+    return () => {
+      window.removeEventListener('scroll', toggleVisibility);
+    };
+  }, []);
+
+  return (
+    <>
+      {isVisible && (
+        <button
+          onClick={scrollToTop}
+          className="fixed bottom-5 right-5 w-12 h-12 bg-blue-500 text-white rounded-full flex items-center justify-center text-2xl shadow-lg hover:bg-blue-600 hover:shadow-xl transition-all duration-300 hover:-translate-y-1 active:translate-y-0 z-50"
+          aria-label="Scroll to top"
+        >
+          ↑
+        </button>
+      )}
+    </>
+  );
 };
 
 const App = () => {
@@ -60,7 +105,7 @@ const App = () => {
               <Toaster />
               <Sonner />
               <BrowserRouter>
-                <ScrollToTop />
+                <ScrollToTopOnRouteChange />
                 <div className="min-h-screen bg-background">
                   <Navbar />
                   <Routes>
@@ -78,6 +123,8 @@ const App = () => {
                     <Route path="*" element={<NotFound />} />
                   </Routes>
                   <Footer />
+                  {/* NEW: Add the floating scroll to top button */}
+                  <ScrollToTopButton />
                 </div>
               </BrowserRouter>
             </TooltipProvider>

--- a/src/components/ScrollToTop.css
+++ b/src/components/ScrollToTop.css
@@ -1,0 +1,47 @@
+.scroll-to-top {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  z-index: 1000;
+}
+
+.scroll-to-top-button {
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  background-color: #3b82f6; /* Tailwind blue-500 */
+  color: white;
+  border: none;
+  outline: none;
+  cursor: pointer;
+  font-size: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  transition: all 0.3s ease;
+}
+
+.scroll-to-top-button:hover {
+  background-color: #2563eb; /* Tailwind blue-600 */
+  transform: translateY(-2px);
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+}
+
+.scroll-to-top-button:active {
+  transform: translateY(0);
+}
+
+/* For mobile responsiveness */
+@media (max-width: 768px) {
+  .scroll-to-top {
+    bottom: 15px;
+    right: 15px;
+  }
+  
+  .scroll-to-top-button {
+    width: 45px;
+    height: 45px;
+    font-size: 20px;
+  }
+}

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -1,0 +1,47 @@
+import { useState, useEffect } from 'react';
+import './ScrollToTop.css'; // We'll create this next
+
+const ScrollToTop = () => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  // Show button when page is scrolled down
+  const toggleVisibility = () => {
+    if (window.pageYOffset > 300) {
+      setIsVisible(true);
+    } else {
+      setIsVisible(false);
+    }
+  };
+
+  // Scroll to top smoothly
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth'
+    });
+  };
+
+  useEffect(() => {
+    window.addEventListener('scroll', toggleVisibility);
+    
+    return () => {
+      window.removeEventListener('scroll', toggleVisibility);
+    };
+  }, []);
+
+  return (
+    <div className="scroll-to-top">
+      {isVisible && (
+        <button
+          onClick={scrollToTop}
+          className="scroll-to-top-button"
+          aria-label="Scroll to top"
+        >
+          ↑
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default ScrollToTop;


### PR DESCRIPTION
- Add ScrollToTopButton component that appears after scrolling 300px
- Button provides smooth scroll to top functionality
- Improve UX for long pages like medicine listings and health info
- Mobile responsive design with hover effects
- Rename existing ScrollToTop to ScrollToTopOnRouteChange for clarity
- Fixes #28

<img width="1366" height="693" alt="image" src="https://github.com/user-attachments/assets/80d55d21-f94c-4c37-b6e3-5e636515e87a" />
<img width="1366" height="686" alt="image" src="https://github.com/user-attachments/assets/b8cb097c-81d5-4e42-a416-9e16274a4e97" />
<img width="1366" height="687" alt="image" src="https://github.com/user-attachments/assets/07fa6188-78bc-4fbe-97b7-5c7c10039a3d" />

i have added some images, due to some hardware issue i am unable to record video but the scroll to top button is working fine you can check