### PR TITLE
feat: add show/hide password toggle in auth forms

### DIFF
--- a/src/components/Auth.tsx
+++ b/src/components/Auth.tsx
@@ -8,7 +8,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { toast } from 'sonner';
-import { Heart, Mail, Lock, User, Phone, Loader2, Shield } from 'lucide-react';
+import { Heart, Mail, Lock, User, Phone, Loader2, Shield, Eye, EyeOff } from 'lucide-react';
 
 const Auth: React.FC = () => {
   const { t, language } = useLanguage();
@@ -19,6 +19,8 @@ const Auth: React.FC = () => {
   const [registerData, setRegisterData] = useState({ name: '', email: '', phone: '', password: '' });
   const [otp, setOtp] = useState('');
   const [loading, setLoading] = useState(false);
+  const [showLoginPassword, setShowLoginPassword] = useState(false);
+  const [showRegisterPassword, setShowRegisterPassword] = useState(false);
 
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -51,6 +53,14 @@ const Auth: React.FC = () => {
     } else {
       toast.error(language === 'hi' ? 'गलत OTP' : 'Invalid OTP');
     }
+  };
+
+  const toggleLoginPasswordVisibility = () => {
+    setShowLoginPassword(!showLoginPassword);
+  };
+
+  const toggleRegisterPasswordVisibility = () => {
+    setShowRegisterPassword(!showRegisterPassword);
   };
 
   if (pendingVerification) {
@@ -165,13 +175,27 @@ const Auth: React.FC = () => {
                     <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-muted-foreground pointer-events-none" />
                     <Input 
                       id="login-password"
-                      type="password" 
+                      type={showLoginPassword ? "text" : "password"} 
                       value={loginData.password} 
                       onChange={(e) => setLoginData(p => ({...p, password: e.target.value}))} 
-                      className="pl-11 h-12 border-2 focus-visible:ring-2 focus-visible:ring-primary transition-all" 
+                      className="pl-11 pr-10 h-12 border-2 focus-visible:ring-2 focus-visible:ring-primary transition-all" 
                       placeholder="••••••••"
                       required
                     />
+                    <button
+                      type="button"
+                      className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                      onClick={toggleLoginPasswordVisibility}
+                      aria-label={showLoginPassword ? 
+                        (language === 'hi' ? 'पासवर्ड छिपाएं' : 'Hide password') : 
+                        (language === 'hi' ? 'पासवर्ड दिखाएं' : 'Show password')}
+                    >
+                      {showLoginPassword ? (
+                        <EyeOff className="w-5 h-5" />
+                      ) : (
+                        <Eye className="w-5 h-5" />
+                      )}
+                    </button>
                   </div>
                 </div>
                 
@@ -255,13 +279,27 @@ const Auth: React.FC = () => {
                     <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-muted-foreground pointer-events-none" />
                     <Input 
                       id="register-password"
-                      type="password" 
+                      type={showRegisterPassword ? "text" : "password"} 
                       value={registerData.password} 
                       onChange={(e) => setRegisterData(p => ({...p, password: e.target.value}))} 
-                      className="pl-11 h-12 border-2 focus-visible:ring-2 focus-visible:ring-primary transition-all" 
+                      className="pl-11 pr-10 h-12 border-2 focus-visible:ring-2 focus-visible:ring-primary transition-all" 
                       placeholder="••••••••"
                       required
                     />
+                    <button
+                      type="button"
+                      className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                      onClick={toggleRegisterPasswordVisibility}
+                      aria-label={showRegisterPassword ? 
+                        (language === 'hi' ? 'पासवर्ड छिपाएं' : 'Hide password') : 
+                        (language === 'hi' ? 'पासवर्ड दिखाएं' : 'Show password')}
+                    >
+                      {showRegisterPassword ? (
+                        <EyeOff className="w-5 h-5" />
+                      ) : (
+                        <Eye className="w-5 h-5" />
+                      )}
+                    </button>
                   </div>
                 </div>
                 


### PR DESCRIPTION
- Add Eye/EyeOff toggle buttons for password visibility in login and registration forms
- Separate state management for login and registration password visibility
- Implement bilingual aria-labels for accessibility (English/Hindi)
- Maintain default masked state for security
- Improve UX by allowing users to verify their password input
- Fixes #29

<img width="1366" height="611" alt="image" src="https://github.com/user-attachments/assets/7f66e39c-bd36-4fd7-9dce-693389628418" />
<img width="1366" height="617" alt="image" src="https://github.com/user-attachments/assets/e021050c-9c51-48b9-8284-a2ddc58db41f" />
<img width="1366" height="619" alt="image" src="https://github.com/user-attachments/assets/188cb979-d792-43e9-8420-1df7696b8c36" />
<img width="1361" height="609" alt="image" src="https://github.com/user-attachments/assets/c6f5cf91-0280-4ac5-baa7-a0485a060e03" />

the hide/show toggle is working fine you can check 