### PR TITLE
fix loading animation error fixes: #64 and #66 (Prevent LoadingScreen crash when LanguageProvider is not initialized)

### DIFF
--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { Heart } from 'lucide-react';
-import { useLanguage } from '../contexts/LanguageContext';
 
 interface LoadingScreenProps {
   onComplete: () => void;
@@ -18,11 +17,9 @@ const LoadingScreen: React.FC<LoadingScreenProps> = ({
 }) => {
   const [progress, setProgress] = useState(0);
 
-  // ✅ Correct hook usage (no try/catch)
-  const language = useLanguage();
-
-  const appName = language?.t?.appName ?? 'स्वास्थ्य साथी';
-  const loadingText = language?.t?.loading ?? 'Loading';
+  // Use static values since LoadingScreen loads before LanguageProvider
+  const appName = 'स्वास्थ्य साथी';
+  const loadingText = 'Loading';
 
   const prefersReducedMotion = useMemo(() => {
     if (typeof window === 'undefined') return false;


### PR DESCRIPTION
### Overview
This PR fixes a runtime error caused by `LoadingScreen` accessing `useLanguage()` before `LanguageProvider` is initialized.

In the current app flow, `LoadingScreen` is rendered early in `App.tsx`, before context providers are mounted. This caused the app to crash with:
`useLanguage must be used within a LanguageProvider`.

---

### Root Cause
- `LoadingScreen` was calling `useLanguage()`
- `LanguageProvider` is initialized later in the app lifecycle
- This resulted in an uncaught runtime error during initial render

---

### What was changed
- Removed `useLanguage()` dependency from `LoadingScreen`
- Replaced dynamic i18n values with safe static fallbacks:
  - App name
  - Loading text
- Ensured `LoadingScreen` works independently of context initialization

---

### Result
- Application no longer crashes during initial load
- Loading screen renders reliably before providers are mounted
- Context usage remains unchanged for the rest of the app

---

### Issue References
- Fixes #64
- Fixes #66