### PR TITLE
feat: add global ErrorBoundary and graceful crash recovery

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,50 @@
+import React, { Component, ErrorInfo, ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+class ErrorBoundary extends Component<Props, State> {
+  state: State = {
+    hasError: false,
+  };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error("ErrorBoundary caught an error:", error, info);
+  }
+
+  handleReload = () => {
+    window.location.reload();
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="min-h-screen flex flex-col items-center justify-center text-center p-6">
+          <h1 className="text-2xl font-bold mb-2">
+            Something went wrong
+          </h1>
+          <p className="text-muted-foreground mb-4">
+            The app encountered an unexpected error. Please try again.
+          </p>
+          <Button onClick={this.handleReload}>
+            Reload App
+          </Button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,4 +2,10 @@ import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
 
-createRoot(document.getElementById("root")!).render(<App />);
+import ErrorBoundary from "@/components/ErrorBoundary";
+
+createRoot(document.getElementById("root")!).render(
+  <ErrorBoundary>
+    <App />
+  </ErrorBoundary>
+);


### PR DESCRIPTION
Closes #48

### Summary
- Added a global ErrorBoundary at the app root
- Prevents white-screen crashes
- Displays a user-friendly fallback UI with reload option

### Proof
- Before: runtime error caused blank screen

<img width="1880" height="1023" alt="Screenshot 2026-01-05 100500" src="https://github.com/user-attachments/assets/5b43591c-02bc-4f89-abba-5db2a4acb0c2" />


- After: ErrorBoundary catches error and allows recovery

<img width="1919" height="1076" alt="Screenshot 2026-01-05 100845" src="https://github.com/user-attachments/assets/b2d93964-b6b8-4557-8ad4-1835a1e78529" />
