### PR TITLE
Add scheduled medicine and appointment reminders 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,8 @@ import Checkout from '@/components/Checkout';
 import Auth from '@/components/Auth';
 import Profile from '@/components/Profile';
 import NotFound from "./pages/NotFound";
+import Reminders from "@/pages/Reminders";
+
 
 const queryClient = new QueryClient();
 
@@ -124,6 +126,8 @@ const App = () => {
                       <Route path="/auth" element={<Auth />} />
                       <Route path="/profile" element={<Profile />} />
                       <Route path="*" element={<NotFound />} />
+                      <Route path="/reminders" element={<Reminders />} />
+
                     </Routes>
                     <Footer />
                     {/* NEW: Add the floating scroll to top button */}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -62,6 +62,8 @@ const Navbar: React.FC = () => {
     { path: '/tips', label: t.healthTips, icon: '🌿', color: 'text-green-600' },
     { path: '/store', label: t.medicineStore, icon: '💊', color: 'text-amber-600' },
     { path: '/assistant', label: t.aiAssistant, icon: '🤖', color: 'text-blue-600' },
+    { path: '/reminders', label: 'Reminders', icon: '⏰', color: 'text-purple-600' },
+
   ];
 
   const moreItems = [

--- a/src/lib/reminderStorage.ts
+++ b/src/lib/reminderStorage.ts
@@ -1,0 +1,11 @@
+import { Reminder } from "@/types/reminder";
+
+const KEY = "sehat-saathi-reminders";
+
+export const getReminders = (): Reminder[] => {
+  return JSON.parse(localStorage.getItem(KEY) || "[]");
+};
+
+export const saveReminders = (reminders: Reminder[]) => {
+  localStorage.setItem(KEY, JSON.stringify(reminders));
+};

--- a/src/pages/Reminders.tsx
+++ b/src/pages/Reminders.tsx
@@ -1,0 +1,159 @@
+import { useEffect, useState } from "react";
+import { Reminder } from "../types/reminder";
+import { getReminders, saveReminders } from "../lib/reminderStorage";
+import { Button } from "../components/ui/button";
+import { Input } from "../components/ui/input";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "../components/ui/card";
+import {
+  Tabs,
+  TabsList,
+  TabsTrigger,
+} from "../components/ui/tabs";
+
+export default function Reminders() {
+  const [reminders, setReminders] = useState<Reminder[]>([]);
+  const [title, setTitle] = useState("");
+  const [type, setType] = useState<"medicine" | "appointment">("medicine");
+  const [time, setTime] = useState("09:00");
+  const [date, setDate] = useState(
+  new Date().toISOString().split("T")[0]
+);
+
+
+  useEffect(() => {
+  if ("Notification" in window && Notification.permission === "default") {
+    Notification.requestPermission();
+  }
+}, []);
+useEffect(() => {
+  const interval = setInterval(() => {
+    const now = new Date();
+
+    const updatedReminders = reminders.map((reminder) => {
+      if (reminder.notified) return reminder;
+
+      const reminderDateTime = new Date(
+        `${reminder.date}T${reminder.time}:00`
+      );
+
+      if (now >= reminderDateTime) {
+        if (Notification.permission === "granted") {
+          new Notification("⏰ Reminder", {
+            body: reminder.title,
+          });
+        }
+
+        return { ...reminder, notified: true };
+      }
+
+      return reminder;
+    });
+
+    setReminders(updatedReminders);
+    saveReminders(updatedReminders);
+  }, 30000); // check every 30 seconds
+
+  return () => clearInterval(interval);
+}, [reminders]);
+
+
+
+  const addReminder = () => {
+    if (!title) return;
+    
+    const newReminder: Reminder = {
+      id: crypto.randomUUID(),
+      type,
+      title,
+      date,
+      time,
+      notified:false,
+    };
+    const updated = [...reminders, newReminder];
+    setReminders(updated);
+    saveReminders(updated);
+    setTitle("");
+  };
+
+  return (
+  <div className="container mx-auto p-4 max-w-3xl">
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          ⏰ Reminders
+        </CardTitle>
+      </CardHeader>
+
+      <CardContent className="space-y-6">
+        {/* Tabs */}
+        <Tabs defaultValue="medicine"
+        onValueChange={(value) => setType(value as "medicine" | "appointment")}>
+          <TabsList className="grid grid-cols-2 w-full">
+            <TabsTrigger value="medicine">💊 Medicine</TabsTrigger>
+            <TabsTrigger value="appointment">📅 Appointment</TabsTrigger>
+          </TabsList>
+        </Tabs>
+
+        {/* Input Section */}
+        <div className="flex flex-wrap gap-2 items-center">
+            <Input
+                placeholder="Enter medicine or appointment"
+                value={title}
+                onChange={(e) => setTitle(e.currentTarget.value)}
+                className="flex-1"
+            />
+
+            <Input
+                type="date"
+                value={date}
+                onChange={(e) => setDate(e.currentTarget.value)}
+                className="w-40 dark:[color-scheme:dark]"
+            />
+
+            <Input
+                type="time"
+                value={time}
+                onChange={(e) => setTime(e.currentTarget.value)}
+                className="w-32 dark:[color-scheme:dark]"
+            />
+
+            <Button onClick={addReminder}>Add</Button>
+        </div>
+
+
+        {/* Reminder List */}
+        <div className="space-y-3">
+          {reminders.length === 0 && (
+            <p className="text-sm text-muted-foreground text-center">
+              No reminders yet. Add one above.
+            </p>
+          )}
+
+          {reminders.map((r) => (
+            <div
+              key={r.id}
+              className="flex items-center justify-between p-3 border rounded-lg hover:bg-muted transition"
+            >
+              <div className="flex items-center gap-3">
+                <span className="text-xl">
+                  {r.type === "medicine" ? "💊" : "📅"}
+                </span>
+                <span className="font-medium">{r.title}</span>
+              </div>
+              <span className="text-sm text-muted-foreground">
+                {r.date} · {r.time}
+              </span>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  </div>
+);
+
+}

--- a/src/types/reminder.ts
+++ b/src/types/reminder.ts
@@ -1,0 +1,11 @@
+export type ReminderType = "medicine" | "appointment";
+
+export interface Reminder {
+  id: string;
+  type: ReminderType;
+  title: string;
+  date: string;
+  time: string;
+  notes?: string;
+  notified?:boolean;
+}


### PR DESCRIPTION
## 🕒 Medicine & Appointment Reminders

### What’s Added
- New **Reminders** page accessible from the navbar
- Support for **medicine** and **appointment** reminders
- User-selectable **date & time scheduling**
- Reminder persistence using LocalStorage
- Improved UI using cards and tabs
- Fixed **date/time picker icon visibility in dark mode**

---

### How It Works
- Users can schedule reminders for any future date and time
- Reminders are stored locally and displayed in a dedicated dashboard
- (Notification delivery is planned as a future enhancement)

---

### Before
📸 *No reminders feature available*
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/123fb860-cbe5-4f77-b0dd-387d4b548327" />

---

### After
📸 *Reminders page with medicine & appointment scheduling*
📸 *Date & time picker visible in dark mode*

---

### Screenshots 
<!-- Attach screenshots or a short screen recording here -->
<img width="1890" height="910" alt="Screenshot 2026-01-05 225101" src="https://github.com/user-attachments/assets/f8310e41-52ed-4f57-a375-9d6b307c7ff1" />
<img width="1885" height="912" alt="Screenshot 2026-01-05 224958" src="https://github.com/user-attachments/assets/6e990561-2ac4-4e13-aab8-da8b349f33b6" />
<img width="398" height="351" alt="image" src="https://github.com/user-attachments/assets/9cf4625c-d8c8-4c1d-a537-09902441a872" />



---

### Notes
- Designed to be easily extended with notifications (PWA / SMS)

Closes #93
