### PR TITLE
Fix chat scroll behavior and Navbar build issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2646,7 +2646,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.23.1",
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
+      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -6055,10 +6057,12 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.2",
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
+      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.1"
+        "@remix-run/router": "1.23.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -6068,11 +6072,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.2",
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
+      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.1",
-        "react-router": "6.30.2"
+        "@remix-run/router": "1.23.2",
+        "react-router": "6.30.3"
       },
       "engines": {
         "node": ">=14.0.0"

--- a/src/components/AIAssistant.tsx
+++ b/src/components/AIAssistant.tsx
@@ -388,8 +388,7 @@ const AIAssistant: React.FC = () => {
 
           <ScrollArea
             ref={scrollAreaRef}
-            className="flex-1 p-4 overflow-auto"
-            style={{ maxHeight: '500px' }}
+            className="flex-1 p-4 overflow-auto min-h-0"
           >
             <div className="space-y-4">
               {messages.map((message) => (

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -247,7 +247,11 @@ const Navbar: React.FC = () => {
                             variant={isActive(item.path) ? 'secondary' : 'ghost'}
                             className={`w-full justify-start gap-4 h-11 ${isActive(item.path) ? 'font-semibold' : ''}`}
                           >
-                            {isStrIcon ? <span className="text-lg">{item.icon}</span> : <item.icon className="w-5 h-5" />}
+                          {isStrIcon ? (
+                              <span className="text-lg">{item.icon as string}</span>
+                          ) : (
+                              <Icon className="w-5 h-5" />
+                          )}
                             {item.label}
                           </Button>
                         </Link>
@@ -270,7 +274,7 @@ const Navbar: React.FC = () => {
                         <Button className="w-full">Log In / Sign Up</Button>
                       </Link>
                     ) : (
-                      <Button variant="destructive" variant="ghost" className="w-full justify-start gap-4 text-destructive hover:text-destructive hover:bg-destructive/10 mt-2" onClick={() => { logout(); setIsOpen(false); }}>
+                      <Button variant="destructive" className="w-full justify-start gap-4 text-destructive hover:text-destructive hover:bg-destructive/10 mt-2" onClick={() => { logout(); setIsOpen(false); }}>
                         <LogOut className="w-5 h-5" />
                         {t.logout}
                       </Button>
@@ -301,7 +305,10 @@ const Navbar: React.FC = () => {
                     variant="ghost"
                     className={`gap-2 rounded-full px-4 h-9 ${active ? 'bg-secondary text-primary hover:bg-secondary/80' : 'text-muted-foreground hover:text-foreground'}`}
                   >
-                    {isStrIcon ? <span>{item.icon}</span> : <Icon className={`w-4 h-4 ${active ? 'fill-current' : ''}`} />}
+                  {isStrIcon
+                    ? <span>{item.icon as string}</span>
+                    : <Icon className={`w-4 h-4 ${active ? 'fill-current' : ''}`} />
+                  }
                     {item.label}
                   </Button>
                 </Link>


### PR DESCRIPTION
🐞 Problem

When the chatbot conversation became long, the chat container expanded vertically instead of becoming scrollable.
Once it reached the footer, the chatbot input field stopped accepting user input, blocking further interaction.

This resulted in:

Layout overflow

Footer overlapping the chat

Chat input becoming unusable

✅ Solution

This PR fixes the issue by properly constraining the chatbot layout and enabling internal scrolling.

Key changes:

Applied correct flexbox constraints to the chat container

Ensured the message list scrolls instead of expanding

Prevented footer interference with the chat input

Fixed a build-breaking issue in Navbar.tsx

🧪 Testing

✅ Long chatbot conversations now scroll correctly

✅ Chat input remains usable at all times

✅ Footer no longer overlaps or blocks interaction

✅ npm run build passes successfully

---

## 📸 Screenshots (if applicable)
Current version 
<img width="1860" height="868" alt="image" src="https://github.com/user-attachments/assets/cd02d0b6-1003-45ee-b851-373495ee6b5d" />

Updated 

https://github.com/user-attachments/assets/832d2425-ff65-4e77-a858-49d6e86fb27f


---

## ✅ Checklist
Please confirm the following:

- [ ] My code follows the project’s coding style
- [x] I have tested my changes
- [ ] I have updated documentation where necessary
- [ ] This PR does not introduce breaking changes

---

closes issue #161 