### PR TITLE
feat: replace text icons with Lucide icons on Health Tips page

### DIFF
--- a/src/components/HealthTips.tsx
+++ b/src/components/HealthTips.tsx
@@ -20,7 +20,8 @@ import {
   Ban,
   Brush,
   Shield,
-  Smartphone,
+  SmartphoneNfc,
+
   AlertTriangle,
   HeartPulse,
   Smile,
@@ -46,7 +47,7 @@ const iconMap: Record<string, React.FC<any>> = {
   ban: Ban,
   broom: Brush,
   shield: Shield,
-  smartphone: Smartphone,
+  smartphone: SmartphoneNfc,
   "alert-triangle": AlertTriangle,
   "heart-pulse": HeartPulse,
   smile: Smile,


### PR DESCRIPTION
## 📌 Description
Replaced text-based labels on the Health Tips page with appropriate Lucide icons to improve visual clarity and consistency.

Fixes: #236
---

## 🔧 Type of Change
Please mark the relevant option(s):

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor / Code cleanup
- [x] 🎨 UI / Styling change
- [ ] 🚀 Other (please describe):

---

## 🧪 How Has This Been Tested?
Describe the tests you ran to verify your changes.

- [ ] Manual testing
- [ ] Automated tests
- [ ] Not tested (please explain why)

---

## 📸 Screenshots (if applicable)
<img width="703" height="587" alt="image" src="https://github.com/user-attachments/assets/bacb30b4-eca7-44b5-a190-dc9238a4e622" />


---

## ✅ Checklist
Please confirm the following:

- [ ] My code follows the project’s coding style
- [x] I have tested my changes
- [ ] I have updated documentation where necessary
- [ ] This PR does not introduce breaking changes

---
