### PR TITLE
Feature: add lab tests section with view and booking flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,10 @@ import HealthTips from '@/components/HealthTips';
 import MedicineStore from '@/components/MedicineStore';
 import AIAssistant from '@/components/AIAssistant';
 import MedicalHistoryPage from '@/pages/MedicalHistory';
+import LabTests from "./pages/LabTests";
+import LabTestDetails from "@/pages/LabTestDetails";
+import LabBooking from "@/pages/LabBooking";
+
 
 import SarkariYojana from '@/components/SarkariYojana';
 import NearbyHospitals from '@/components/NearbyHospitals';
@@ -127,6 +131,9 @@ const App = () => {
                       <Route path="/tips" element={<HealthTips />} />
                       <Route path="/store" element={<MedicineStore />} />
                       <Route path="/medical-history" element={<MedicalHistoryPage />} />
+                      <Route path="/lab-tests" element={<LabTests />} />
+                      <Route path="/lab-tests/:id" element={<LabTestDetails />} />
+                      <Route path="/lab-tests/:id/book" element={<LabBooking />} />
 
                       <Route path="/assistant" element={<AIAssistant />} />
                       <Route path="/schemes" element={<SarkariYojana />} />

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,5 +1,6 @@
-
+﻿
 import React, { useState } from 'react';
+import { Bell, FlaskConical } from 'lucide-react';
 import { Link, useLocation } from 'react-router-dom';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { useAuth } from '@/contexts/AuthContext';
@@ -68,6 +69,8 @@ const Navbar: React.FC = () => {
     { path: '/nearby', label: t.nearbyHospitals, icon: MapPin },
     { path: '/reminders', label: 'Reminders', icon: '⏰' },
     { path: '/medical-history', label: 'Medical History', icon: FileText },
+    { path: '/lab-tests', label: 'Lab Tests', icon: FlaskConical },
+
   ];
 
   const isActive = (path: string) => location.pathname === path;
@@ -290,7 +293,7 @@ const Navbar: React.FC = () => {
       {/* Desktop Navigation (Bottom Row) */}
       <div className="hidden lg:block bg-background/50 backdrop-blur-sm">
         <div className="container mx-auto px-4">
-          <div className="flex items-center gap-1 h-12 overflow-x-auto no-scrollbar">
+          <div className="flex items-center gap-1 h-12 overflow-hidden">
             {navItems.map((item) => {
               const active = isActive(item.path);
               const Icon = typeof item.icon === 'string' ? Activity : item.icon;
@@ -303,11 +306,11 @@ const Navbar: React.FC = () => {
                 >
                   <Button
                     variant="ghost"
-                    className={`gap-2 rounded-full px-4 h-9 ${active ? 'bg-secondary text-primary hover:bg-secondary/80' : 'text-muted-foreground hover:text-foreground'}`}
+                    className={`gap-1 rounded-full px-3 h-8 text-sm ${active ? 'bg-secondary text-primary hover:bg-secondary/80' : 'text-muted-foreground hover:text-foreground'}`}
                   >
                   {isStrIcon
                     ? <span>{item.icon as string}</span>
-                    : <Icon className={`w-4 h-4 ${active ? 'fill-current' : ''}`} />
+                    : <Icon className="w-3.5 h-3.5" />
                   }
                     {item.label}
                   </Button>

--- a/src/lib/labTestStorage.ts
+++ b/src/lib/labTestStorage.ts
@@ -1,0 +1,16 @@
+import { LabTest } from "@/types/labTest";
+
+const KEY = "sehat-saathi-lab-tests";
+
+export const getLabTests = (): LabTest[] => {
+  const saved = localStorage.getItem(KEY);
+  try {
+    return saved ? JSON.parse(saved) : [];
+  } catch {
+    return [];
+  }
+};
+
+export const saveLabTests = (tests: LabTest[]) => {
+  localStorage.setItem(KEY, JSON.stringify(tests));
+};

--- a/src/pages/LabBooking.tsx
+++ b/src/pages/LabBooking.tsx
@@ -1,0 +1,37 @@
+import { useParams } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+
+const LabBooking = () => {
+  const { id } = useParams();
+
+  return (
+    <div className="container mx-auto px-4 py-6 max-w-md space-y-6">
+      <h1 className="text-xl font-semibold">
+        Book: {id?.replace("-", " ")}
+      </h1>
+
+      <div className="space-y-3">
+        <input
+          placeholder="Patient Name"
+          className="w-full p-3 rounded-md border bg-background"
+        />
+        <input
+          placeholder="Mobile Number"
+          className="w-full p-3 rounded-md border bg-background"
+        />
+        <input
+          type="date"
+          className="w-full p-3 rounded-md border bg-background"
+        />
+      </div>
+
+      <Button className="w-full">Confirm Booking</Button>
+
+      <p className="text-xs text-muted-foreground text-center">
+        Booking is currently a demo (no payment required)
+      </p>
+    </div>
+  );
+};
+
+export default LabBooking;

--- a/src/pages/LabTestDetails.tsx
+++ b/src/pages/LabTestDetails.tsx
@@ -1,0 +1,32 @@
+import { useParams, Link } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+
+const LabTestDetails = () => {
+  const { id } = useParams();
+
+  return (
+    <div className="container mx-auto px-4 py-6 max-w-2xl space-y-6">
+      <h1 className="text-2xl font-semibold capitalize">
+        {id?.replace("-", " ")}
+      </h1>
+
+      <p className="text-muted-foreground">
+        This package includes detailed diagnostic tests conducted by
+        certified labs with home sample collection.
+      </p>
+
+      <ul className="list-disc pl-5 text-sm space-y-1">
+        <li>Home sample collection</li>
+        <li>NABL certified labs</li>
+        <li>Digital reports</li>
+        <li>Doctor-friendly format</li>
+      </ul>
+
+      <Link to={`/lab-tests/${id}/book`}>
+        <Button className="w-full">Book Now</Button>
+      </Link>
+    </div>
+  );
+};
+
+export default LabTestDetails;

--- a/src/pages/LabTests.tsx
+++ b/src/pages/LabTests.tsx
@@ -1,0 +1,175 @@
+import {
+  FlaskConical,
+  TestTube2,
+  Activity,
+  ShieldCheck,
+  Home as HomeIcon,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Link } from "react-router-dom";
+
+
+const LabTests = () => {
+  return (
+    <div className="container mx-auto px-4 py-6 space-y-10">
+      {/* Header */}
+      <div>
+        <h1 className="text-2xl font-semibold flex items-center gap-2">
+          <FlaskConical className="w-6 h-6 text-primary" />
+          Lab Tests
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          Book diagnostic tests from trusted labs
+        </p>
+      </div>
+
+      {/* Top Feature Cards */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <FeatureCard
+          icon={<HomeIcon />}
+          title="Home Sample Collection"
+          desc="Samples collected at your doorstep"
+        />
+        <FeatureCard
+          icon={<ShieldCheck />}
+          title="Trusted Labs"
+          desc="NABL & ISO certified labs"
+        />
+        <FeatureCard
+          icon={<Activity />}
+          title="Accurate Reports"
+          desc="Digital reports in 24–48 hrs"
+        />
+      </div>
+
+      {/* Popular Packages */}
+      <section>
+        <h2 className="text-lg font-semibold mb-4">
+          Popular Health Packages
+        </h2>
+
+        <div className="flex gap-4 overflow-x-auto pb-2 no-scrollbar">
+          <PackageCard
+            title="Full Body Checkup"
+            tests="70+ tests"
+            price="₹999"
+          />
+          <PackageCard
+            title="Diabetes Care"
+            tests="5 tests"
+            price="₹399"
+          />
+          <PackageCard
+            title="Thyroid Care"
+            tests="3 tests"
+            price="₹499"
+          />
+        </div>
+      </section>
+
+      {/* Individual Tests */}
+      <section>
+        <h2 className="text-lg font-semibold mb-4">
+          Individual Lab Tests
+        </h2>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <TestCard
+            name="Complete Blood Count (CBC)"
+            report="24 hrs"
+            price="₹299"
+          />
+          <TestCard
+            name="HbA1c (Diabetes)"
+            report="24 hrs"
+            price="₹399"
+          />
+          <TestCard
+            name="Thyroid Profile"
+            report="24–48 hrs"
+            price="₹499"
+          />
+          <TestCard
+            name="Vitamin D"
+            report="48 hrs"
+            price="₹699"
+          />
+        </div>
+      </section>
+    </div>
+  );
+};
+
+/* ---------------- Components ---------------- */
+
+const FeatureCard = ({
+  icon,
+  title,
+  desc,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  desc: string;
+}) => (
+  <div className="flex gap-3 p-4 rounded-xl border border-border bg-background/40 backdrop-blur-sm">
+    <div className="text-primary">{icon}</div>
+    <div>
+      <p className="font-medium">{title}</p>
+      <p className="text-sm text-muted-foreground">{desc}</p>
+    </div>
+  </div>
+);
+
+const PackageCard = ({
+  title,
+  tests,
+  price,
+}: {
+  title: string;
+  tests: string;
+  price: string;
+}) => (
+  <div className="min-w-[240px] p-4 rounded-xl border border-border bg-background/40 backdrop-blur-sm hover:shadow-md transition">
+    <h3 className="font-medium">{title}</h3>
+    <p className="text-sm text-muted-foreground">{tests}</p>
+    <div className="flex justify-between items-center mt-4">
+      <span className="font-semibold text-primary">{price}</span>
+      <Link to="/lab-tests/full-body-checkup">
+        <Button size="sm">View</Button>
+      </Link>
+
+    </div>
+  </div>
+);
+
+const TestCard = ({
+  name,
+  report,
+  price,
+}: {
+  name: string;
+  report: string;
+  price: string;
+}) => (
+  <div className="p-4 rounded-xl border border-border bg-background/40 backdrop-blur-sm hover:shadow-md transition">
+    <div className="flex items-start gap-2">
+      <TestTube2 className="w-5 h-5 text-primary mt-1" />
+      <div>
+        <p className="font-medium">{name}</p>
+        <p className="text-sm text-muted-foreground">
+          Report in {report}
+        </p>
+      </div>
+    </div>
+
+    <div className="flex justify-between items-center mt-4">
+      <span className="font-semibold">{price}</span>
+      <Link to="/lab-tests/cbc/book">
+        <Button size="sm">Book</Button>
+      </Link>
+
+    </div>
+  </div>
+);
+
+export default LabTests;

--- a/src/types/labTest.ts
+++ b/src/types/labTest.ts
@@ -1,0 +1,8 @@
+export interface LabTest {
+  id: string;
+  testName: string;
+  value: string;
+  unit: string;
+  date: string;
+  uploadedFile?: string; // base64 (optional)
+}


### PR DESCRIPTION
## 📌 Description
This PR introduces a new **Lab Tests** section to the application, inspired by platforms like PharmEasy.

Users can now:
- View available lab test packages
- Click **View** to see detailed test information
- Click **Book** to proceed with booking flow
- Access Lab Tests directly from the Navbar

This enhancement improves health monitoring by allowing users to explore and initiate lab tests from within the app.

Fixes: #239

---

## 🔧 Type of Change
- [ ] 🐛 Bug fix  
- [x] ✨ New feature  
- [ ] 📝 Documentation update  
- [ ] ♻️ Refactor / Code cleanup  
- [x] 🎨 UI / Styling change  
- [ ] 🚀 Other  

---

## 🧪 How Has This Been Tested?
- [x] Manual testing  
- [ ] Automated tests  
- [ ] Not tested  

### Tested Scenarios:
- Lab Tests page loads correctly
- View button opens lab test details page
- Book button navigates to booking page
- Navbar link routes correctly to Lab Tests
- No impact on existing routes or features

---

## 📸 Screenshots
Screenshots attached showing:
- Lab Tests listing page
<img width="1857" height="903" alt="image" src="https://github.com/user-attachments/assets/54ea8e9a-50f1-4a5f-9280-61206d243e5c" />

- View details page
<img width="1878" height="489" alt="image" src="https://github.com/user-attachments/assets/e97cd942-df2f-43a5-aea8-445c7ddb35a4" />

- Booking page flow
<img width="1880" height="557" alt="image" src="https://github.com/user-attachments/assets/d4ac1a43-a842-43b9-bbf2-2d5257120139" />

---

## ✅ Checklist
- [x] My code follows the project’s coding style
- [x] I have tested my changes locally
- [ ] I have updated documentation (not required for this feature)
- [x] This PR does not introduce breaking changes

---

## 📝 Additional Notes
- Data is currently stored locally for demo purposes
- Feature is designed to be extended later with:
  - Report uploads
  - Export functionality
  - Reminders integration

I would like to consider this contribution under **ECWoC'26**.
