### PR TITLE
Fix: Change Default Website Language to English Instead of Hindi (#373)

### DIFF
--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -609,10 +609,10 @@ interface LanguageContextType {
 const LanguageContext = createContext<LanguageContextType | undefined>(undefined);
 
 export const LanguageProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
-  const [language, setLanguage] = useState<Language>(() => {
-    const saved = localStorage.getItem('language');
-    return (saved as Language) || 'hi';
-  });
+ const [language, setLanguage] = useState<Language>(() => {
+  const saved = localStorage.getItem('language');
+  return (saved as Language) || 'en';
+});
 
   const handleSetLanguage = (lang: Language) => {
     setLanguage(lang);


### PR DESCRIPTION
## 🐛 Bug Fix: Default Language Set to English

### 🔍 Issue
The website was defaulting to Hindi (`hi`) when no language preference was stored in localStorage.

### ✅ Fix
Updated the fallback default language from `'hi'` to `'en'`.

Closes #373 